### PR TITLE
Fix some default settings issues

### DIFF
--- a/src/dotnet/PowerToys.CyclomaticComplexity/ComplexityAnalysisElementProblemAnalyzer.cs
+++ b/src/dotnet/PowerToys.CyclomaticComplexity/ComplexityAnalysisElementProblemAnalyzer.cs
@@ -38,7 +38,7 @@ namespace JetBrains.ReSharper.Plugins.CyclomaticComplexity
   public class ComplexityAnalysisElementProblemAnalyzer : ElementProblemAnalyzer<ITreeNode>
   {
     private readonly Key<State> key = new Key<State>("ComplexityAnalyzerState");
-    
+
 #if RIDER
     private readonly ComplexityCodeInsightsProvider _provider;
     private readonly IconHost _iconHost;
@@ -49,7 +49,7 @@ namespace JetBrains.ReSharper.Plugins.CyclomaticComplexity
       _iconHost = iconHost;
     }
 #endif
-    
+
     protected override void Run(ITreeNode element, ElementProblemAnalyzerData data, IHighlightingConsumer consumer)
     {
       // We get a fresh data for each file, so we can cache some state to make
@@ -104,12 +104,7 @@ namespace JetBrains.ReSharper.Plugins.CyclomaticComplexity
     private static int GetThreshold(ElementProblemAnalyzerData data, PsiLanguageType language)
     {
       var threshold = data.SettingsStore.GetIndexedValue((CyclomaticComplexityAnalysisSettings s) => s.Thresholds, language.Name);
-      if (threshold < 1)
-      {
-        data.SettingsStore.SetIndexedValue((CyclomaticComplexityAnalysisSettings s) => s.Thresholds, language.Name, CyclomaticComplexityAnalysisSettings.DefaultThreshold);
-        threshold = CyclomaticComplexityAnalysisSettings.DefaultThreshold;
-      }
-      return threshold;
+      return threshold < 1 ? CyclomaticComplexityAnalysisSettings.DefaultThreshold : threshold;
     }
 
     private static int CalculateCyclomaticComplexity(IControlFlowGraph graph)
@@ -260,7 +255,7 @@ namespace JetBrains.ReSharper.Plugins.CyclomaticComplexity
       if (declaration?.DeclaredElement != null)
         return element;
 
-      // Don't have a declared element to highlight. Going to have to guess. Try the 
+      // Don't have a declared element to highlight. Going to have to guess. Try the
       // first meaningful child
       return element.GetNextMeaningfulChild(null);
     }

--- a/src/dotnet/PowerToys.CyclomaticComplexity/Resources/DefaultSettings.xml
+++ b/src/dotnet/PowerToys.CyclomaticComplexity/Resources/DefaultSettings.xml
@@ -2,9 +2,10 @@
 <wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                         xmlns:s="clr-namespace:System;assembly=mscorlib"
                         xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml"
-                        xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation"> 
+                        xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:Int64 x:Key="/Default/CodeInspection/CyclomaticComplexityAnalysis/Thresholds/=CSHARP/@EntryIndexedValue">20</s:Int64>
 	<s:Int64 x:Key="/Default/CodeInspection/CyclomaticComplexityAnalysis/Thresholds/=CPP/@EntryIndexedValue">20</s:Int64>
 	<s:Int64 x:Key="/Default/CodeInspection/CyclomaticComplexityAnalysis/Thresholds/=JAVA_SCRIPT/@EntryIndexedValue">20</s:Int64>
 	<s:Int64 x:Key="/Default/CodeInspection/CyclomaticComplexityAnalysis/Thresholds/=TYPE_SCRIPT/@EntryIndexedValue">20</s:Int64>
+	<s:Int64 x:Key="/Default/CodeInspection/CyclomaticComplexityAnalysis/Thresholds/=VBASIC/@EntryIndexedValue">20</s:Int64>
 </wpf:ResourceDictionary>


### PR DESCRIPTION
This PR will:

- [x] No longer update settings with a default threshold while running analysis, to prevent settings change notifications causing ripple effects
- [x] Add a default threshold for `VBASIC`. All control flow graph languages should have default thresholds now
